### PR TITLE
Add created FileSet instance to the list when ant core calls createFileset

### DIFF
--- a/src/com/avlesh/antwebtasks/war/CacheBuster.java
+++ b/src/com/avlesh/antwebtasks/war/CacheBuster.java
@@ -240,7 +240,10 @@ public class CacheBuster {
   }
 
   public FileSet createFileset() {
-    return new FileSet();
+    FileSet fileSet = new FileSet();
+    this.fileSets.add(fileSet);
+
+    return fileSet;
   }
 
   public CacheBusterRule createRule() {

--- a/src/com/avlesh/antwebtasks/war/Inject.java
+++ b/src/com/avlesh/antwebtasks/war/Inject.java
@@ -51,7 +51,10 @@ public class Inject {
     }
 
     public FileSet createFileset() {
-        return new FileSet();
+        FileSet fileSet = new FileSet();
+        this.fileSets.add(fileSet);
+
+        return fileSet;
     }
 
     public void init() {


### PR DESCRIPTION
Ant manuals say (see [here](https://ant.apache.org/manual/develop.html#nested-elements)) that you only need to implement either of `createXYZ()`, `addXYZ()` or `addConfiguredXYZ()` to accept any nested elements under a custom target. If more than one is present, which one will be called is non deterministic  and depends on the JVM.

`Inject` class supplies both `createFileset()` and `addFileset()` methods, so any one of them may be called. The problem is that `createFileset()` does not save a reference (see this [example](http://ant.apache.org/manual/tutorial-writing-tasks.html#NestedElements)) to the newly created `FileSet`.
On occasions where `createFileset()` is called instead of `addFileset()`, we never get a reference to the nested `<fileset>` elements and `fileSets` stays empty. The task then ends up pre-processing all files instead of only the included ones and ruins binary files due to character encoding conversions.

Ideally only one of the methods should be present but this PR will only go as far as adding the created `FileSet` to the `fileSets` list.